### PR TITLE
fix: wrong array index for custom channel

### DIFF
--- a/RufflesTransport/RufflesTransport.cs
+++ b/RufflesTransport/RufflesTransport.cs
@@ -224,9 +224,9 @@ namespace RufflesTransport
 
             for (byte i = (byte)MLAPI_CHANNELS.Length; i < Channels.Count + MLAPI_CHANNELS.Length; i++)
             {
-                config.ChannelTypes[i] = Channels[i].Type;
-                channelIdToName.Add(i, Channels[i].Name);
-                channelNameToId.Add(Channels[i].Name, i);
+                config.ChannelTypes[i] = Channels[config.ChannelTypes.Length - 1 - i].Type;
+                channelIdToName.Add(i, Channels[config.ChannelTypes.Length - 1 - i].Name);
+                channelNameToId.Add(Channels[config.ChannelTypes.Length - 1 - i].Name, i);
             }
 
             return config;


### PR DESCRIPTION
when accessing custom channels defined in the unity editor during socket configuration creation the Channels list was used with a wrong index i, which started at 7 (number of channels of MLAPI_CHANNELS) instead of 0.