### PR TITLE
fix(LiteNetLibTransport): Transport fails to acknowledge connect/disc…

### DIFF
--- a/LiteNetLibTransport/LiteNetLibTransport.cs
+++ b/LiteNetLibTransport/LiteNetLibTransport.cs
@@ -136,9 +136,9 @@ namespace LiteNetLibTransport
 
                     payload = new ArraySegment<byte>(data, 0, size);
                     @event.packetReader.Recycle();
-
-                    return @event.type;
                 }
+
+                return @event.type;
             }
 
             return NetEventType.Nothing;


### PR DESCRIPTION
…onnect events

LiteNetLibTransport.PollEvents now returns the correct event type for Connect/Disconnect events,
which lets MLAPI properly handle connection and disconnection instead of receiving
NetEventType.Nothing.