### PR TITLE
Fix:OnServerFound method on editor

### DIFF
--- a/com.community.netcode.extensions/Runtime/NetworkDiscovery/ExampleNetworkDiscoveryHud.cs
+++ b/com.community.netcode.extensions/Runtime/NetworkDiscovery/ExampleNetworkDiscoveryHud.cs
@@ -43,7 +43,14 @@ public class ExampleNetworkDiscoveryHud : MonoBehaviour
 
     void OnServerFound(IPEndPoint sender, DiscoveryResponseData response)
     {
-        discoveredServers[sender.Address] = response;
+        if (discoveredServers.ContainsKey(sender.Address))
+        {
+            discoveredServers[sender.Address] = response;
+        }
+        else
+        {
+            discoveredServers.Add(sender.Address, response);
+        }
     }
 
     void OnGUI()


### PR DESCRIPTION
On Unity Editor, if discoveredServers disctionary did not already cointained the sender.Address, the method would do nothing. Now, it correctly ads the new discovered server to the dictionary.