### PR TITLE
Don't use MonoBehaviour methods in transports

### DIFF
--- a/Transports/com.community.netcode.transport.enet/Runtime/EnetTransport.cs
+++ b/Transports/com.community.netcode.transport.enet/Runtime/EnetTransport.cs
@@ -9,7 +9,6 @@ using EventType = ENet.EventType;
 
 namespace Netcode.Transports.Enet
 {
-    [DefaultExecutionOrder(1000)]
     public class EnetTransport : NetworkTransport
     {
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
@@ -71,7 +70,7 @@ namespace Netcode.Transports.Enet
             connectedEnetPeers[peerId].Send(0, ref packet);
         }
 
-        public void Update()
+        protected override void OnPostLateUpdate()
         {
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
             s_Flush.Begin();

--- a/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
+++ b/Transports/com.community.netcode.transport.facepunch/Runtime/FacepunchTransport.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Steamworks;
@@ -17,6 +16,7 @@ namespace Netcode.Transports.Facepunch
         private ConnectionManager connectionManager;
         private SocketManager socketManager;
         private Dictionary<ulong, Client> connectedClients;
+        private bool m_SteamInitialized;
 
         [Space]
         [Tooltip("The Steam App ID of your game. Technically you're not allowed to use 480, but Valve doesn't do anything about it so it's fine for testing purposes.")]
@@ -38,38 +38,26 @@ namespace Netcode.Transports.Facepunch
             public SocketConnection connection;
         }
 
-        #region MonoBehaviour Messages
+        #region NetworkTransport Overrides
 
-        private void Awake()
-        {
-            try
-            {
-                SteamClient.Init(steamAppId, false);
-            }
-            catch (Exception e)
-            {
-                if (LogLevel <= LogLevel.Error)
-                    Debug.LogError($"[{nameof(FacepunchTransport)}] - Caught an exeption during initialization of Steam client: {e}");
-            }
-            finally
-            {
-                StartCoroutine(InitSteamworks());
-            }
-        }
-
-        private void Update()
+        protected override void OnEarlyUpdate()
         {
             SteamClient.RunCallbacks();
+
+            if (!m_SteamInitialized && SteamClient.IsValid)
+            {
+                m_SteamInitialized = true;
+                SteamNetworkingUtils.InitRelayNetworkAccess();
+
+                if (LogLevel <= LogLevel.Developer)
+                    Debug.Log($"[{nameof(FacepunchTransport)}] - Initialized access to Steam Relay Network.");
+
+                userSteamId = SteamClient.SteamId;
+
+                if (LogLevel <= LogLevel.Developer)
+                    Debug.Log($"[{nameof(FacepunchTransport)}] - Fetched user Steam ID.");
+            }
         }
-
-        private void OnDestroy()
-        {
-            SteamClient.Shutdown();
-        }
-
-        #endregion
-
-        #region NetworkTransport Overrides
 
         public override ulong ServerClientId => 0;
 
@@ -105,6 +93,16 @@ namespace Netcode.Transports.Facepunch
         public override void Initialize(NetworkManager networkManager = null)
         {
             connectedClients = new Dictionary<ulong, Client>();
+
+            try
+            {
+                SteamClient.Init(steamAppId, false);
+            }
+            catch (Exception e)
+            {
+                if (LogLevel <= LogLevel.Error)
+                    Debug.LogError($"[{nameof(FacepunchTransport)}] - Caught an exeption during initialization of Steam client: {e}");
+            }
         }
 
         private SendType NetworkDeliveryToSendType(NetworkDelivery delivery)
@@ -129,6 +127,7 @@ namespace Netcode.Transports.Facepunch
 
                 connectionManager?.Close();
                 socketManager?.Close();
+                SteamClient.Shutdown();
             }
             catch (Exception e)
             {
@@ -285,23 +284,6 @@ namespace Netcode.Transports.Facepunch
         }
 
         #endregion
-
-        #region Utility Methods
-
-        private IEnumerator InitSteamworks()
-        {
-            yield return new WaitUntil(() => SteamClient.IsValid);
-
-            SteamNetworkingUtils.InitRelayNetworkAccess();
-
-            if (LogLevel <= LogLevel.Developer)
-                Debug.Log($"[{nameof(FacepunchTransport)}] - Initialized access to Steam Relay Network.");
-
-            userSteamId = SteamClient.SteamId;
-
-            if (LogLevel <= LogLevel.Developer)
-                Debug.Log($"[{nameof(FacepunchTransport)}] - Fetched user Steam ID.");
-        }
 
         #endregion
     }

--- a/Transports/com.community.netcode.transport.litenetlib/Runtime/LiteNetLibTransport.cs
+++ b/Transports/com.community.netcode.transport.litenetlib/Runtime/LiteNetLibTransport.cs
@@ -60,7 +60,7 @@ namespace Netcode.Transports.LiteNetLib
             SimulateMaxLatency = Math.Max(SimulateMinLatency, SimulateMaxLatency);
         }
 
-        void Update()
+        protected override void OnEarlyUpdate()
         {
             m_NetManager?.PollEvents();
         }

--- a/Transports/com.community.netcode.transport.multipeer-connectivity/Runtime/MultipeerConnectivityTransport.cs
+++ b/Transports/com.community.netcode.transport.multipeer-connectivity/Runtime/MultipeerConnectivityTransport.cs
@@ -333,7 +333,7 @@ namespace Netcode.Transports.MultipeerConnectivity
         /// </summary>
         public event Action<string> OnConnectingWithPeer;
 
-        public override void Initialize(NetworkManager networkManager)
+        public override void Initialize(NetworkManager networkManager = null)
         {
             // Initialize the singleton instance
             if (s_instance != null && s_instance != this)

--- a/Transports/com.community.netcode.transport.multipeer-connectivity/Runtime/MultipeerConnectivityTransport.cs
+++ b/Transports/com.community.netcode.transport.multipeer-connectivity/Runtime/MultipeerConnectivityTransport.cs
@@ -333,21 +333,19 @@ namespace Netcode.Transports.MultipeerConnectivity
         /// </summary>
         public event Action<string> OnConnectingWithPeer;
 
-        private void Awake()
+        public override void Initialize(NetworkManager networkManager)
         {
             // Initialize the singleton instance
             if (s_instance != null && s_instance != this)
             {
                 Destroy(gameObject);
+                return;
             }
             else
             {
                 s_instance = this;
             }
-        }
 
-        public override void Initialize(NetworkManager networkManager)
-        {
             if (!IsRuntime)
             {
                 Debug.LogError($"[MPCTransport] MPCTransport cannot run in Unity Editor, it can only run on an iOS device. " +

--- a/Transports/com.community.netcode.transport.photon-realtime/Runtime/PhotonRealtimeTransport.cs
+++ b/Transports/com.community.netcode.transport.photon-realtime/Runtime/PhotonRealtimeTransport.cs
@@ -11,7 +11,6 @@ using UnityEngine.Serialization;
 
 namespace Netcode.Transports.PhotonRealtime
 {
-    [DefaultExecutionOrder(-1000)]
     public partial class PhotonRealtimeTransport : NetworkTransport, IOnEventCallback
     {
         private static readonly ArraySegment<byte> s_EmptyArraySegment = new ArraySegment<byte>(Array.Empty<byte>());
@@ -93,12 +92,12 @@ namespace Netcode.Transports.PhotonRealtime
         ///<inheritdoc/>
         public override ulong ServerClientId => GetMlapiClientId(0, true);
 
-        // -------------- MonoBehaviour Handlers --------------------------------------------------------------------------
+        // -------------- NetworkTransport Handlers ----------------------------------------------------------------------
 
         /// <summary>
-        /// In Update before other scripts run we dispatch incoming commands.
+        /// Dispatch incoming Photon commands before processing received packets.
         /// </summary>
-        void Update()
+        protected override void OnEarlyUpdate()
         {
             if (m_Client != null)
             {
@@ -107,9 +106,9 @@ namespace Netcode.Transports.PhotonRealtime
         }
 
         /// <summary>
-        /// Send batched messages out in LateUpdate.
+        /// Send batched messages out after processing.
         /// </summary>
-        void LateUpdate()
+        protected override void OnPostLateUpdate()
         {
             if (m_Client != null)
             {


### PR DESCRIPTION
Avoiding relying on the `MonoBehaviour` methods to run a transport gives us better control of when its code will execute, which could provide better performance. It also makes it easier to wrap a transport in a system that doesn't relay on the GameObject update loop to execute.